### PR TITLE
Fix and prettify

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -38,7 +38,7 @@ jobs:
       - name: "Run CompatHelper"
         run: |
           import CompatHelper
-          CompatHelper.main(; master_branch="main")
+          CompatHelper.main(; master_branch="dev")
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 Memoization = "6fafb56a-5788-4b4e-91ca-c0cea6611c73"
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
 QEDcore = "35dc0263-cb5f-4c33-a114-1d7f54ab753e"
+QEDprocesses = "46de9c38-1bb3-4547-a1ec-da24d767fdad"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]

--- a/src/computable_dags/compute.jl
+++ b/src/computable_dags/compute.jl
@@ -17,7 +17,7 @@ end
 import ComputableDAGs: compute, compute_effort, children
 
 const e = sqrt(4π / 137)
-_vertex() = -1im * e * gamma()
+const VERTEX = -1im * e * gamma()
 
 compute_effort(::ComputeTask_BaseState) = 0
 compute_effort(::ComputeTask_Propagator) = 0
@@ -117,21 +117,21 @@ end
     photon::Propagated{Photon,V1},
     electron::Propagated{Electron,V2},
 ) where {V1,V2}
-    return Unpropagated(Electron(), photon.value * _vertex() * electron.value) # photon - electron -> electron
+    return Unpropagated(Electron(), photon.value * VERTEX * electron.value) # photon - electron -> electron
 end
 @inline function compute( # photon, positron
     ::ComputeTask_Pair,
     photon::Propagated{Photon,V1},
     positron::Propagated{Positron,V2},
 ) where {V1,V2}
-    return Unpropagated(Positron(), positron.value * _vertex() * photon.value) # photon - positron -> positron
+    return Unpropagated(Positron(), positron.value * VERTEX * photon.value) # photon - positron -> positron
 end
 @inline function compute( # electron, positron
     ::ComputeTask_Pair,
     electron::Propagated{Electron,V1},
     positron::Propagated{Positron,V2},
 ) where {V1,V2}
-    return Unpropagated(Photon(), positron.value * _vertex() * electron.value)  # electron - positron -> photon
+    return Unpropagated(Photon(), positron.value * VERTEX * electron.value)  # electron - positron -> photon
 end
 
 @inline function compute(
@@ -156,7 +156,7 @@ end
     electron::Propagated{Electron,V2},
     positron::Propagated{Positron,V3},
 ) where {V1,V2,V3}
-    return positron.value * (_vertex() * photon.value) * electron.value
+    return positron.value * (VERTEX * photon.value) * electron.value
 end
 
 # this compiles in a reasonable amount of time for up to about 1e4 parameters

--- a/src/computable_dags/compute.jl
+++ b/src/computable_dags/compute.jl
@@ -84,7 +84,10 @@ function compute( #=@inline=#
     end
 
     vp_species = particle_species(input.vp)
-    return QEDbase.propagator(vp_species, vp_mom)
+    #println("$vp_species with $vp_mom")
+    inner = QEDbase.propagator(vp_species, vp_mom)
+    println("inner: $(inner[1, 1])")
+    return inner
     # diracmatrix or scalar number
 end
 
@@ -182,8 +185,14 @@ end
 
 # this compiles in a reasonable amount of time for up to about 1e4 parameters
 # use a summation algorithm with more accuracy and/or parallelization
-compute(::ComputeTask_CollectPairs, args::Vararg{N,T}) where {N,T} = sum(args) #=@inline=#
-compute(::ComputeTask_CollectTriples, args::Vararg{N,T}) where {N,T} = sum(args) #=@inline=#
+function compute(::ComputeTask_CollectPairs, args::Vararg{N,T}) where {N,T}
+    println("summing $args")
+    return sum(args)
+end
+function compute(::ComputeTask_CollectTriples, args::Vararg{N,T}) where {N,T}
+    println("summing $args")
+    return sum(args)
+end
 function compute(::ComputeTask_SpinPolCumulation, args::Vararg{N,T}) where {N,T} #=@inline=#
     sum = 0.0
     for arg in args

--- a/src/computable_dags/generation.jl
+++ b/src/computable_dags/generation.jl
@@ -321,10 +321,15 @@ function generate_DAG(proc::AbstractProcessDefinition)
 
     # TODO: use the spin/pol iterator here once it has been implemented
     # -- Base State Tasks --
-    base_state_task_outputs = Dict()
+    propagated_outputs = Dict{VirtualParticle,Vector{Node}}()
     for dir in (Incoming(), Outgoing())
         for species in (Electron(), Positron(), Photon())
             for index in 1:number_particles(proc, dir, species)
+                p = VirtualParticle(
+                    proc,
+                    is_outgoing(dir) ? _invert(species) : species,
+                    _momentum_contribution(proc, dir, species, index)...,
+                )
                 for spin_pol in _spin_pols(spin_or_pol(proc, dir, species, index))
                     # gen entry nodes
                     # names are "bs_<dir>_<species>_<spin/pol>_<index>"
@@ -344,7 +349,10 @@ function generate_DAG(proc::AbstractProcessDefinition)
                     insert_edge!(graph, data_in, compute_base_state)
                     insert_edge!(graph, compute_base_state, data_out)
 
-                    base_state_task_outputs[data_node_name] = data_out
+                    if !haskey(propagated_outputs, p)
+                        propagated_outputs[p] = Vector{Node}()
+                    end
+                    push!(propagated_outputs[p], data_out)
                 end
             end
         end
@@ -369,9 +377,8 @@ function generate_DAG(proc::AbstractProcessDefinition)
     end
 
     # -- Pair Tasks --
-    pair_task_outputs = Dict{VirtualParticle,Vector{Node}}()
     for (product_particle, input_particle_vector) in pairs
-        pair_task_outputs[product_particle] = Vector{Node}()
+        propagated_outputs[product_particle] = Vector{Node}()
 
         # make a dictionary of vectors to collect the outputs depending on spin/pol configs of the input particles
         N = _number_contributions(product_particle)
@@ -381,21 +388,10 @@ function generate_DAG(proc::AbstractProcessDefinition)
 
         for input_particles in input_particle_vector
             # input_particles is a tuple of first and second particle
-            particles_data_out_nodes = (Vector(), Vector())
-            c = 0
-            for p in input_particles
-                c += 1
-                if (is_external(p))
-                    # grab from base_states (broadcast over _base_state_name because it is a tuple for different spin_pols)
-                    push!.(
-                        Ref(particles_data_out_nodes[c]),
-                        getindex.(Ref(base_state_task_outputs), _base_state_name(p)),
-                    )
-                else
-                    # grab from propagated particles
-                    append!(particles_data_out_nodes[c], pair_task_outputs[p])
-                end
-            end
+            particles_data_out_nodes = (
+                propagated_outputs[input_particles[1]],
+                propagated_outputs[input_particles[2]],
+            )
 
             for in_nodes in Iterators.product(particles_data_out_nodes...)
                 # make the compute pair nodes for every combination of the found input_particle_nodes to get all spin/pol combinations
@@ -450,28 +446,17 @@ function generate_DAG(proc::AbstractProcessDefinition)
 
             insert_edge!(graph, compute_propagated, data_out_propagated)
 
-            push!(pair_task_outputs[product_particle], data_out_propagated)
+            push!(propagated_outputs[product_particle], data_out_propagated)
         end
     end
 
     # -- Triples --
     triples_results = Dict()
     for (ph, el, po) in triples    # for each triple (each "diagram")
-        photons = if is_external(ph)
-            getindex.(Ref(base_state_task_outputs), _base_state_name(ph))
-        else
-            pair_task_outputs[ph]
-        end
-        electrons = if is_external(el)
-            getindex.(Ref(base_state_task_outputs), _base_state_name(el))
-        else
-            pair_task_outputs[el]
-        end
-        positrons = if is_external(po)
-            getindex.(Ref(base_state_task_outputs), _base_state_name(po))
-        else
-            pair_task_outputs[po]
-        end
+        photons = propagated_outputs[ph]
+        electrons = propagated_outputs[el]
+        positrons = propagated_outputs[po]
+
         for (a, b, c) in Iterators.product(photons, electrons, positrons) # for each spin/pol config of each part
             compute_triples = insert_node!(graph, ComputeTask_Triple())
             data_triples = insert_node!(graph, DataTask(0))


### PR DESCRIPTION
The generation code has been improved a bit and now makes use of the new edge sorting in `ComputableDAGs`. This allows a lot of the `compute` overloads to be removed.

I compared the results for Compton scattering processes with single spin/pol combinations with the results of the previous implementation and fixed things to make them equal.

I also improved the initial `Propagator` tasks so they now require almost no allocations, and generally improved the compute functions so the profiler now essentially only shows time spent in `*`, `+`, and `RuntimeGeneratedFunctions`-related overhead.