### PR TITLE
Massively improve generation performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QEDFeynmanDiagrams"
 uuid = "3232ad24-8ec1-4588-843e-e2ed2eae1ff3"
-authors = ["AntonReinhard <a.reinhard@hzdr.de>", "Uwe Hernandez Acosta <u.hernandez@hzdr.de>"]
 version = "0.1.0"
+authors = ["AntonReinhard <a.reinhard@hzdr.de>", "Uwe Hernandez Acosta <u.hernandez@hzdr.de>"]
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/computable_dags/compute.jl
+++ b/src/computable_dags/compute.jl
@@ -82,8 +82,8 @@ end
 end
 
 function _vp_momentum(
-    vp::VirtualParticle{PROC,SPECIES,I,O}, psp::AbstractPhaseSpacePoint
-) where {PROC,SPECIES,I,O}
+    vp::VirtualParticle{PROC,I,O}, psp::AbstractPhaseSpacePoint
+) where {PROC,I,O}
     return _masked_sum(momenta(psp, Incoming()), _in_contributions(vp)) -
            _masked_sum(momenta(psp, Outgoing()), _out_contributions(vp))
 end

--- a/src/computable_dags/compute.jl
+++ b/src/computable_dags/compute.jl
@@ -42,7 +42,9 @@ struct BaseStateInput{PS_T<:AbstractParticleStateful,SPIN_POL_T<:AbstractSpinOrP
     spin_pol::SPIN_POL_T
 end
 
-function compute(::ComputeTask_BaseState, input::BaseStateInput)
+function compute(
+    ::ComputeTask_BaseState, input::BaseStateInput{PS_T,SPIN_POL_T}
+) where {PS_T<:AbstractParticleStateful,SPIN_POL_T<:AbstractSpinOrPolarization}
     species = particle_species(input.particle)
     if is_outgoing(input.particle)
         species = _invert(species)
@@ -62,7 +64,7 @@ end
 
 struct PropagatorInput{VP_T<:VirtualParticle,PSP_T<:AbstractPhaseSpacePoint}
     vp::VP_T
-    psp::Ref{PSP_T}
+    psp::PSP_T
 end
 
 @inline _masked_sum(::Tuple{}, ::Tuple{}) = error("masked sum needs at least one argument")
@@ -89,7 +91,7 @@ end
 function compute(
     ::ComputeTask_Propagator, input::PropagatorInput{VP_T,PSP_T}
 ) where {VP_T,PSP_T}
-    vp_mom = _vp_momentum(input.vp, input.psp[])
+    vp_mom = _vp_momentum(input.vp, input.psp)
     vp_species = particle_species(input.vp)
     inner = QEDbase.propagator(vp_species, vp_mom)
     return inner

--- a/src/computable_dags/generation.jl
+++ b/src/computable_dags/generation.jl
@@ -114,7 +114,7 @@ function ComputableDAGs.input_expr(
                                 $(vp.in_particle_contributions),
                                 $(vp.out_particle_contributions)
                               ),
-                              Ref($psp_symbol)
+                              $psp_symbol
                           )")
     else
         throw(InvalidInputError("failed to parse node name \"$name\""))
@@ -124,16 +124,14 @@ end
 function ComputableDAGs.input_type(p::AbstractProcessDefinition)
     # TODO correctly assemble abstract types here
     # See https://github.com/QEDjl-project/QEDFeynmanDiagrams.jl/issues/29
-    return Any
     in_t = QEDcore._assemble_tuple_type(incoming_particles(p), Incoming(), SFourMomentum)
     out_t = QEDcore._assemble_tuple_type(outgoing_particles(p), Outgoing(), SFourMomentum)
-    return PhaseSpacePoint{
+    return AbstractPhaseSpacePoint{
         typeof(p),
-        PerturbativeQED,
-        PhasespaceDefinition{SphericalCoordinateSystem,ElectronRestFrame},
+        <:AbstractModelDefinition,
+        <:AbstractPhasespaceDefinition,
         Tuple{in_t...},
         Tuple{out_t...},
-        SFourMomentum,
     }
 end
 

--- a/src/computable_dags/generation.jl
+++ b/src/computable_dags/generation.jl
@@ -98,7 +98,7 @@ function ComputableDAGs.input_expr(
 
         return Meta.parse(
             "QEDFeynmanDiagrams.BaseStateInput(
-                ParticleStateful($dir_str, $species_str, momentum($psp_symbol, $dir_str, $species_str, $index)),
+                ParticleStateful($dir_str, $species_str, momentum($psp_symbol, $dir_str, $species_str, Val($index))),
                 $sp_str,
             )",
         )
@@ -368,8 +368,12 @@ end
 
 Generate and return a [`ComputableDAGs.DAG`](@extref), representing the computation for the squared matrix element of this scattering process, summed over spin and polarization combinations allowed by the process.
 """
-function generate_DAG(proc::AbstractProcessDefinition)
-    particles = virtual_particles(proc)                  # virtual particles that will be input to propagator tasks
+function generate_DAG(proc::PROC) where {PROC<:AbstractProcessDefinition}
+    I = number_incoming_particles(proc)
+    O = number_outgoing_particles(proc)
+    SPECIFIC_VP = VirtualParticle{PROC,NTuple{I,Bool},NTuple{O,Bool}}
+    particles::Vector{SPECIFIC_VP} = virtual_particles(proc)                  # virtual particles that will be input to propagator tasks
+
     # TODO apparently this sort is deprecated, change it
     pairs = sort(particle_pairs(particles))              # pairs to generate the pair tasks
     triples = sort(total_particle_triples(particles))    # triples to generate the triple tasks

--- a/src/flat_matrix.jl
+++ b/src/flat_matrix.jl
@@ -2,7 +2,7 @@
 # for internal use only
 struct FlatMatrix{T,N,M}
     values::NTuple{N,T}
-    indices::NTuple{M,Int}
+    indices::NTuple{M,Int64}
 
     function FlatMatrix(v::Vector{Vector{T}}) where {T}
         M = length(v)
@@ -11,7 +11,14 @@ struct FlatMatrix{T,N,M}
         values = NTuple{N,T}(vcat(v...))
         indices = ntuple(i -> sum(length.(v[1:(i - 1)])), M)
 
-        return new{Int,N,M}(values, indices)
+        return new{T,N,M}(values, indices)
+    end
+
+    function FlatMatrix{T,N,M}(v::Vector{Vector{T}}) where {N,M,T}
+        values = NTuple{N,T}(vcat(v...))
+        indices = ntuple(i -> sum(length.(v[1:(i - 1)])), M)
+
+        return new{T,N,M}(values, indices)
     end
 end
 


### PR DESCRIPTION
- This changes the generation of DAGs to a much more efficient algorithm which doesn't need to iterate through all the `feynman_diagrams(proc)`, which scales `~O(n!)`, and instead just generates all possible virtual particles directly, only taking `~O(2^n)`.
- Fixes a proper input type for the generated functions.
- Various compute-time performance improvements